### PR TITLE
fix IsComplexType NullReferenceException

### DIFF
--- a/CefSharp/Internals/JavascriptObjectRepository.cs
+++ b/CefSharp/Internals/JavascriptObjectRepository.cs
@@ -738,7 +738,7 @@ namespace CefSharp.Internals
                 baseType = Nullable.GetUnderlyingType(type);
             }
 
-            if (baseType == null || baseType.IsArray || baseType.Namespace.StartsWith("System"))
+            if (baseType == null || baseType.IsArray || (baseType.Namespace != null && baseType.Namespace.StartsWith("System")))
             {
                 return false;
             }


### PR DESCRIPTION
**Fixes:** 

**Summary:** Sometimes, the registered Javascript object does not have a namespace, at this time this function will throw a ```NullReferenceException```.

**Changes:** 
      - Add null reference check for IsComplexType function 
      
**How Has This Been Tested?**  
This problem is obvious and does not need to be tested 

**Screenshots (if appropriate):**

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated documentation

**Checklist:**
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Tested the code(if applicable)
- [ ] Commented my code
- [ ] Changed the documentation(if applicable)
- [ ] New files have a license disclaimer
- [ ] The formatting is consistent with the project (project supports .editorconfig)
